### PR TITLE
Hide "platform" if None, Add the option to hide the title

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Add a new custom card to your Dashboard:
 ```YAML
 type: custom:swiss-stationboard
 name: Abfahrt
+hide_title: true
 entity:
   - sensor.schupfen
 ```

--- a/dist/swiss-stationboard.js
+++ b/dist/swiss-stationboard.js
@@ -70,7 +70,11 @@ class SwissPublicTransportCard extends LitElement {
                   class="shrink ${departure.delayed}"
                   style="text-align:right;"
                 >
-                 Gleis ${departure.platform}
+                ${departure.platform
+                  ? html`
+                  Gleis ${departure.platform}`
+                  : html``
+                 }
                 </td>
               </tr>
             `

--- a/dist/swiss-stationboard.js
+++ b/dist/swiss-stationboard.js
@@ -30,7 +30,9 @@ class SwissPublicTransportCard extends LitElement {
     this._update_departures(state);
     return html`
       <ha-card id="hacard">
-        <div class="card-header">
+        ${this._config.hide_title
+          ? html``
+          : html`<div class="card-header">
           ${state.attributes.friendly_name}
           ${this._config.show_last_changed
             ? html`
@@ -38,7 +40,9 @@ class SwissPublicTransportCard extends LitElement {
               'N/A'
             </div>`
             : html``
-           }
+          }`
+        }     
+         
         </div>
         <table>
           <tbody id="departuretable">


### PR DESCRIPTION
I've changed the platform display to not display "Gleis " if there is no plaform set, e.g. for a Bus stop which is also returned by the Open Transport API.
Also, I have made it possible to hide the title alltogether.