### PR TITLE
Customization of minutes and seconds labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ entity:
 * `hide_title`: hides the title if true.
 * `category`: regular expression to filter by categories (S-train, Bus, ICE, ...).  i.e. to include multiple categories use the OR operator: `category: B|^ICE$|S`
 * `show_last_changed`: if true, shows the last time that the underlying data changed.
-* `minutes_string`: the string denoting minutes in the ETA field.  Defaults to ` min` or ` mins` depending on how many minutes are left.  Note the whitespace before the word — if your chosen string does not have whitespace, the string will be stuck to the number.
-* `seconds_string`: the string denoting seconds in the ETA field.  Defaults to `″`.  The same note about whitespace that `minutes_string` has applies here too.
+* `minutes_label`: the string denoting minutes in the ETA field.  Defaults to ` min` or ` mins` depending on how many minutes are left.  Note the whitespace before the word — if your chosen string does not have whitespace, the string will be stuck to the number.
+* `seconds_label`: the string denoting seconds in the ETA field.  Defaults to `″`.  The same note about whitespace that `minutes_string` has applies here too.
 
 ## Privacy 
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ entity:
 * `hide_title`: hides the title if true.
 * `category`: regular expression to filter by categories (S-train, Bus, ICE, ...).  i.e. to include multiple categories use the OR operator: `category: B|^ICE$|S`
 * `show_last_changed`: if true, shows the last time that the underlying data changed.
+* `minutes_string`: the string denoting minutes in the ETA field.  Defaults to ` min` or ` mins` depending on how many minutes are left.  Note the whitespace before the word — if your chosen string does not have whitespace, the string will be stuck to the number.
+* `seconds_string`: the string denoting seconds in the ETA field.  Defaults to `″`.  The same note about whitespace that `minutes_string` has applies here too.
 
 ## Privacy 
 

--- a/dist/swiss-stationboard.js
+++ b/dist/swiss-stationboard.js
@@ -147,14 +147,17 @@ class SwissPublicTransportCard extends LitElement {
       {
         const minutes = Math.floor(absoluttotalseconds / 60);
         const seconds = absoluttotalseconds % 60;
-        eta = "in ";
-        var minsStr = ((minutes > 1) ? " mins" : " min";
-        minsStr = this._config.minutes_string ? this._config.minutes_string : minsStr;
+        eta = "in";
+        var minsStr = (minutes > 1) ? " mins" : " min";
+        minsStr = this._config.minutes_label ? this._config.minutes_label : minsStr;
         var secsStr = "″";
-        var secsStr = this._config.seconds_string ? this._config.seconds_string : minsStr;
-        eta += minutes + minsStr);
+        var secsStr = this._config.seconds_label ? this._config.seconds_label : minsStr;
+        eta += " " + minutes + minsStr;
         if (this._config.show_seconds)
-          eta += seconds + secsStr;
+          eta += " " + seconds + secsStr;
+        // Corner case 0m 0s
+        if (eta == "in")
+          eta = "";
       }
       
       // allow category filtering by regex (S-Bahn, Bus, ...)

--- a/dist/swiss-stationboard.js
+++ b/dist/swiss-stationboard.js
@@ -148,7 +148,9 @@ class SwissPublicTransportCard extends LitElement {
         const minutes = Math.floor(absoluttotalseconds / 60);
         const seconds = absoluttotalseconds % 60;
         eta = "in ";
-        eta += minutes + ((minutes > 1) ? " mins" : " min");
+        var minsStr = ((minutes > 1) ? "mins" : "min";
+        minsStr = this._config.minutes_string ? this._config.minutes_string : minsStr;
+        eta += minutes + " " + minsStr);
         if (this._config.show_seconds)
           eta += seconds + "″";
       }

--- a/dist/swiss-stationboard.js
+++ b/dist/swiss-stationboard.js
@@ -148,11 +148,13 @@ class SwissPublicTransportCard extends LitElement {
         const minutes = Math.floor(absoluttotalseconds / 60);
         const seconds = absoluttotalseconds % 60;
         eta = "in ";
-        var minsStr = ((minutes > 1) ? "mins" : "min";
+        var minsStr = ((minutes > 1) ? " mins" : " min";
         minsStr = this._config.minutes_string ? this._config.minutes_string : minsStr;
-        eta += minutes + " " + minsStr);
+        var secsStr = "″";
+        var secsStr = this._config.seconds_string ? this._config.seconds_string : minsStr;
+        eta += minutes + minsStr);
         if (this._config.show_seconds)
-          eta += seconds + "″";
+          eta += seconds + secsStr;
       }
       
       // allow category filtering by regex (S-Bahn, Bus, ...)

--- a/info.md
+++ b/info.md
@@ -25,6 +25,10 @@ entity:
   - sensor.schupfen
 ```
 
+## Settings documentation
+
+The settings are documented here: https://github.com/neuhausf/lovelace-swiss-stationboard
+
 ## Privacy 
 
 This integration uses:


### PR DESCRIPTION
This allows users to customize what gets displayed in lieu of `in XX mins YY"` providing for the possibility of narrower cards that fit mobile better.