### PR TITLE
Adjust delay to only be visible when larger than 1min

### DIFF
--- a/dist/swiss-stationboard.js
+++ b/dist/swiss-stationboard.js
@@ -68,7 +68,7 @@ class SwissPublicTransportCard extends LitElement {
                   class="shrink ${departure.delayed}"
                   style="text-align:right;"
                 >
-                 ${departure.delay > 0?html`(+${departure.delay}')`:html``} ${departure.eta}&nbsp;
+                 ${departure.delay > 1?html`(+${departure.delay}')`:html``} ${departure.eta}&nbsp;
                 </td>
                 <td
                   class="shrink ${departure.delayed}"


### PR DESCRIPTION
Purely stylistic, but could be of interest.

Currently, the API returns a default delay of 1 minute, and this is always visible.
This change will omit outputting a delay when it is 1 minute as well.

This logic is already present when calculating whether there is a delay, and when calculating the "in x minutes" status.